### PR TITLE
Remove old CNAME.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-codefornewark.org
+


### PR DESCRIPTION
Hi, I'm part of Code for Newark. We are working on a new site at https://code4newark.github.io/codefornewark.org/.  Could you free up this CNAME so that we can use codefornewark.org on the new site?

Thanks!